### PR TITLE
Target 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
  language: scala
  scala:
    - 2.11.11
-   - 2.12.6
+   - 2.12.8
+   - 2.13.0
  jdk:
    - oraclejdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.0.0 (2019-06-19)
+
+This is a binary-incompatible release.
+
+ * Target Scala 2.13, and cross-compile for 2.11 and 2.12
+ * `InputUnmarshaller.getMapKeys(node: Node)` now returns an `Iterable[String]`
+
 ## v1.0.3 (2018-05-11)
 
 The release should be compatible with v1.0.0, so no update to the downstream libraries is necessary. 
@@ -44,4 +51,4 @@ The release should be compatible with v1.0.0, so no update to the downstream lib
 
 ## v0.1.0 (2016-01-23)
 
-* Initial release 
+* Initial release

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A common API implemented by different marshalling libraries (like sangria-spray-
 SBT Configuration:
 
 ```scala
-libraryDependencies += "org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.3"
+libraryDependencies += "org.sangria-graphql" %% "sangria-marshalling-api" % "2.0.0"
 ```
 
 ## License

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,13 @@ crossScalaVersions := Seq("2.11.12", "2.12.8", scalaVersion.value)
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
+scalacOptions ++= {
+  if (scalaVersion.value startsWith "2.11")
+    Seq("-target:jvm-1.7")
+  else
+    Seq.empty
+}
+
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.8" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "sangria-marshalling-api"
 organization := "org.sangria-graphql"
-version := "1.0.4-SNAPSHOT"
+version := "2.0.0-SNAPSHOT"
 
 description := "Sangria Marshalling API"
 homepage := Some(url("http://sangria-graphql.org"))

--- a/build.sbt
+++ b/build.sbt
@@ -6,20 +6,13 @@ description := "Sangria Marshalling API"
 homepage := Some(url("http://sangria-graphql.org"))
 licenses := Seq("Apache License, ASL Version 2.0" → url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-scalaVersion := "2.12.6"
-crossScalaVersions := Seq("2.11.11", "2.12.6")
+scalaVersion := "2.13.0"
+crossScalaVersions := Seq("2.11.12", "2.12.8", scalaVersion.value)
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
-scalacOptions ++= {
-  if (scalaVersion.value startsWith "2.12")
-    Seq.empty
-  else
-    Seq("-target:jvm-1.7")
-}
-
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.5" % Test
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test
 )
 
 // Publishing

--- a/src/main/scala/sangria/marshalling/ArrayMapBuilder.scala
+++ b/src/main/scala/sangria/marshalling/ArrayMapBuilder.scala
@@ -2,7 +2,7 @@ package sangria.marshalling
 
 import scala.annotation.tailrec
 import scala.collection.immutable.{ListMap, VectorBuilder}
-import scala.collection.mutable.{Set ⇒ MutableSet}
+import scala.collection.mutable.{Set => MutableSet}
 
 /**
   * GraphQL `Map` builder that knows keys in advance and able to preserve an original fields sort order
@@ -15,7 +15,7 @@ class ArrayMapBuilder[T](keys: Seq[String]) extends Iterable[(String, T)] {
   def add(key: String, elem: T) = {
     val idx = indexLookup(key)
 
-    elements(idx) = key → elem
+    elements(idx) = key -> elem
     indexesSet += idx
 
     this
@@ -24,7 +24,7 @@ class ArrayMapBuilder[T](keys: Seq[String]) extends Iterable[(String, T)] {
   override lazy val toList: List[(String, T)] = {
     val builder = List.newBuilder[(String, T)]
 
-    for (i ← 0 to elements.length if indexesSet contains i) {
+    for (i <- 0 to elements.length if indexesSet contains i) {
       builder += elements(i)
     }
 
@@ -34,7 +34,7 @@ class ArrayMapBuilder[T](keys: Seq[String]) extends Iterable[(String, T)] {
   lazy val toMap: Map[String, T] = {
     val builder = Map.newBuilder[String, T]
 
-    for (i ← 0 to elements.length if indexesSet contains i) {
+    for (i <- 0 to elements.length if indexesSet contains i) {
       builder += elements(i)
     }
 
@@ -44,7 +44,7 @@ class ArrayMapBuilder[T](keys: Seq[String]) extends Iterable[(String, T)] {
   lazy val toListMap: ListMap[String, T] = {
     val builder = ListMap.newBuilder[String, T]
 
-    for (i ← 0 to elements.length if indexesSet contains i) {
+    for (i <- 0 to elements.length if indexesSet contains i) {
       builder += elements(i)
     }
 
@@ -56,7 +56,7 @@ class ArrayMapBuilder[T](keys: Seq[String]) extends Iterable[(String, T)] {
   override lazy val toVector: Vector[(String, T)] = {
     val builder = new VectorBuilder[(String, T)]
 
-    for (i ← 0 to elements.length if indexesSet contains i) {
+    for (i <- 0 to elements.length if indexesSet contains i) {
       builder += elements(i)
     }
 

--- a/src/main/scala/sangria/marshalling/FromInput.scala
+++ b/src/main/scala/sangria/marshalling/FromInput.scala
@@ -20,9 +20,9 @@ object FromInput {
 
     def fromResult(node: marshaller.Node) =
       node.asInstanceOf[Seq[Any]].map {
-        case optElem: Option[_] ⇒
-          optElem map (elem ⇒ delegate.fromResult(elem.asInstanceOf[delegate.marshaller.Node]))
-        case elem ⇒
+        case optElem: Option[_] =>
+          optElem map (elem => delegate.fromResult(elem.asInstanceOf[delegate.marshaller.Node]))
+        case elem =>
           delegate.fromResult(elem.asInstanceOf[delegate.marshaller.Node])
       }.asInstanceOf[Seq[T]]
   }

--- a/src/main/scala/sangria/marshalling/InputUnmarshaller.scala
+++ b/src/main/scala/sangria/marshalling/InputUnmarshaller.scala
@@ -10,7 +10,7 @@ trait InputUnmarshaller[Node] {
 
   def isMapNode(node: Node): Boolean
   def getMapValue(node: Node, key: String): Option[Node]
-  def getMapKeys(node: Node): Traversable[String]
+  def getMapKeys(node: Node): Iterable[String]
 
   def isListNode(node: Node): Boolean
   def getListValue(node: Node): Seq[Node]

--- a/src/main/scala/sangria/marshalling/MarshallingUtil.scala
+++ b/src/main/scala/sangria/marshalling/MarshallingUtil.scala
@@ -6,27 +6,27 @@ object MarshallingUtil {
     val rm = implicitly[ResultMarshallerForType[Out]].marshaller
 
     val converted = value match {
-      case nil if !iu.isDefined(nil) ⇒ rm.nullNode
-      case map if iu.isMapNode(map) ⇒
+      case nil if !iu.isDefined(nil) => rm.nullNode
+      case map if iu.isMapNode(map) =>
         val keys = iu.getMapKeys(map)
         val builder = keys.foldLeft(rm.emptyMapNode(keys.toSeq)) {
-          case (acc, key) ⇒
+          case (acc, key) =>
             iu.getMapValue(map, key) match {
-              case Some(v) ⇒ rm.addMapNodeElem(acc, key, convert(v).asInstanceOf[rm.Node], optional = false)
-              case None ⇒ acc
+              case Some(v) => rm.addMapNodeElem(acc, key, convert(v).asInstanceOf[rm.Node], optional = false)
+              case None => acc
             }
         }
 
         rm.mapNode(builder)
-      case list if iu.isListNode(list) ⇒
-        rm.mapAndMarshal(iu.getListValue(list), (elem: In) ⇒ convert(elem).asInstanceOf[rm.Node])
-      case enum if iu.isEnumNode(enum) && iu.getScalaScalarValue(enum).isInstanceOf[String] ⇒
+      case list if iu.isListNode(list) =>
+        rm.mapAndMarshal(iu.getListValue(list), (elem: In) => convert(elem).asInstanceOf[rm.Node])
+      case enum if iu.isEnumNode(enum) && iu.getScalaScalarValue(enum).isInstanceOf[String] =>
         rm.enumNode(iu.getScalaScalarValue(enum).asInstanceOf[String], "Conversion")
-      case scalar if iu.isScalarNode(scalar) ⇒
+      case scalar if iu.isScalarNode(scalar) =>
         rm.scalarNode(iu.getScalaScalarValue(scalar), "Conversion", Set.empty)
-      case variable if iu.isVariableNode(variable) ⇒
+      case variable if iu.isVariableNode(variable) =>
         throw new IllegalArgumentException(s"Variable '${iu.getVariableName(value)}' found in the input, but variables are not supported in conversion!")
-      case node ⇒
+      case node =>
         throw new IllegalStateException(s"Unexpected node '$node'!")
     }
 
@@ -43,7 +43,7 @@ object MarshallingUtil {
 
     def map(elements: (String, ResultMarshaller#Node)*): m.Node =
       m.mapNode(elements.foldLeft(m.emptyMapNode(elements.map(_._1))) {
-        case (acc, (name, value)) ⇒ m.addMapNodeElem(acc, name, value.asInstanceOf[m.Node], optional = false)
+        case (acc, (name, value)) => m.addMapNodeElem(acc, name, value.asInstanceOf[m.Node], optional = false)
       })
 
     def fromString(value: String): m.Node =

--- a/src/main/scala/sangria/marshalling/ResultMarshaller.scala
+++ b/src/main/scala/sangria/marshalling/ResultMarshaller.scala
@@ -44,10 +44,10 @@ trait ResultMarshaller {
   def renderCompact(node: Node): String
   def renderPretty(node: Node): String
 
-  def mapAndMarshal[T](seq: Seq[T], fn: T ⇒ Node): Node = {
+  def mapAndMarshal[T](seq: Seq[T], fn: T => Node): Node = {
     val res = new VectorBuilder[Node]
 
-    for (elem ← seq) {
+    for (elem <- seq) {
       res += fn(elem)
     }
 

--- a/src/main/scala/sangria/marshalling/scalaMarshalling.scala
+++ b/src/main/scala/sangria/marshalling/scalaMarshalling.scala
@@ -26,8 +26,8 @@ class ScalaResultMarshaller extends ResultMarshaller {
 
   def arrayNode(values: Vector[Node]) = values
   def optionalArrayNodeValue(value: Option[Node]) = value match {
-    case Some(v) ⇒ v
-    case None ⇒ nullNode
+    case Some(v) => v
+    case None => nullNode
   }
 
   def emptyMapNode(keys: Seq[String]) = new ArrayMapBuilder[Node](keys)
@@ -43,14 +43,14 @@ class ScalaResultMarshaller extends ResultMarshaller {
 }
 
 class ScalaInputUnmarshaller[T] extends InputUnmarshaller[T @@ ScalaInput] {
-  def getRootMapValue(node: T @@ ScalaInput, key: String) = node.asInstanceOf[Map[String, Any]] get key map (v ⇒ tag[ScalaInput](v.asInstanceOf[T]))
+  def getRootMapValue(node: T @@ ScalaInput, key: String) = node.asInstanceOf[Map[String, Any]] get key map (v => tag[ScalaInput](v.asInstanceOf[T]))
 
   def isMapNode(node: T @@ ScalaInput) = node.isInstanceOf[Map[_, _]]
-  def getMapValue(node: T @@ ScalaInput, key: String) = node.asInstanceOf[Map[String, _]] get key map (v ⇒ tag[ScalaInput](v.asInstanceOf[T]))
+  def getMapValue(node: T @@ ScalaInput, key: String) = node.asInstanceOf[Map[String, _]] get key map (v => tag[ScalaInput](v.asInstanceOf[T]))
   def getMapKeys(node: T @@ ScalaInput) = node.asInstanceOf[Map[String, _]].keys
 
   def isListNode(node: T @@ ScalaInput) = node.isInstanceOf[Seq[_]]
-  def getListValue(node: T @@ ScalaInput) = node.asInstanceOf[Seq[_]] map (v ⇒ tag[ScalaInput](v.asInstanceOf[T]))
+  def getListValue(node: T @@ ScalaInput) = node.asInstanceOf[Seq[_]] map (v => tag[ScalaInput](v.asInstanceOf[T]))
 
   def isDefined(node: T @@ ScalaInput) = node != null
 

--- a/src/test/scala/sangria/marshalling/ArrayMapBuilderSpec.scala
+++ b/src/test/scala/sangria/marshalling/ArrayMapBuilderSpec.scala
@@ -43,8 +43,8 @@ class ArrayMapBuilderSpec extends WordSpec with Matchers with Inspectors {
 
     "export the data as Iterator" in new PreparedBuilder {
       forAll(builders) { builder =>
-        checkIterator(builder.toIterator)
-        checkIterator(builder.toIterator)
+        checkIterator(builder.iterator)
+        checkIterator(builder.iterator)
       }
     }
 

--- a/src/test/scala/sangria/marshalling/ArrayMapBuilderSpec.scala
+++ b/src/test/scala/sangria/marshalling/ArrayMapBuilderSpec.scala
@@ -30,26 +30,26 @@ class ArrayMapBuilderSpec extends WordSpec with Matchers with Inspectors {
 
   "ArrayMapBuilder" should {
     "export the data as List" in new PreparedBuilder {
-      forAll(builders) { builder ⇒
+      forAll(builders) { builder =>
         builder.toList should be(List(("k1", "v1"), ("k3", "v3")))
       }
     }
 
     "export the data as Vector" in new PreparedBuilder {
-      forAll(builders) { builder ⇒
+      forAll(builders) { builder =>
         builder.toVector should be(Vector(("k1", "v1"), ("k3", "v3")))
       }
     }
 
     "export the data as Iterator" in new PreparedBuilder {
-      forAll(builders) { builder ⇒
+      forAll(builders) { builder =>
         checkIterator(builder.toIterator)
         checkIterator(builder.toIterator)
       }
     }
 
     "export the data as Iterable" in new PreparedBuilder {
-      forAll(builders) { builder ⇒
+      forAll(builders) { builder =>
         val iterable = builder
         iterable.toVector should be(Vector(("k1", "v1"), ("k3", "v3")))
         checkIterator(iterable.iterator)
@@ -80,7 +80,7 @@ class ArrayMapBuilderSpec extends WordSpec with Matchers with Inspectors {
       val iter = builder.iterator
 
       iter.hasNext should be (true)
-      iter.next() should be ("b" → "v")
+      iter.next() should be ("b" -> "v")
       iter.hasNext should be (false)
 
       a [NoSuchElementException] should be thrownBy iter.next()


### PR DESCRIPTION
In preparation of building Sangria for Scala 2.13 it's dependencies must also target 2.13. This PR should prepare the marshalling library for a new release.

Changing from `Traversable[String]` to `Iterable[String]` is a breaking change, which mandates a major version update.
