### PR TITLE
doc(InputUnmarshaller): add info that scala's scalars include map values

### DIFF
--- a/src/main/scala/sangria/marshalling/InputUnmarshaller.scala
+++ b/src/main/scala/sangria/marshalling/InputUnmarshaller.scala
@@ -38,6 +38,7 @@ trait InputUnmarshaller[Node] {
     *   - Double
     *   - scala.BigInt
     *   - scala.BigDecimal
+    *   - Map[String, Node]
     *
     * @return Only normal scala scalar values
     */


### PR DESCRIPTION
please review 🙏

### Motivation
This PR is part of the series that aims to make Apollo federation possible in Sangria, and it comes as a response to the json as scalar support, federation issue discussed [here](https://github.com/sangria-graphql/sangria/issues/462).

### Changes
This PR updates the scaladoc of the InputUnmarshaller **getScalaScalarValue** function, by making explicit that map values can be returned as scala's scalars too.
