### PR TITLE
Add Iterable subtype bound to FromInput

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core._
+
 val isScala3 = Def.setting(
   CrossVersion.partialVersion(scalaVersion.value).exists(_._1 == 3)
 )
@@ -10,6 +12,17 @@ mimaPreviousArtifacts := {
   else
     Set("org.sangria-graphql" %% "sangria-marshalling-api" % "1.0.5")
 }
+mimaBinaryIssueFilters ++= Seq(
+  ProblemFilters.exclude[IncompatibleMethTypeProblem](
+    "sangria.marshalling.CoercedScalaResultMarshaller.mapAndMarshal"),
+  ProblemFilters.exclude[IncompatibleResultTypeProblem]("sangria.marshalling.FromInput.seqInput"),
+  ProblemFilters.exclude[IncompatibleResultTypeProblem]("sangria.marshalling.FromInput.seqInput"),
+  ProblemFilters.exclude[MissingClassProblem]("sangria.marshalling.FromInput$SeqFromInput"),
+  ProblemFilters.exclude[DirectMissingMethodProblem](
+    "sangria.marshalling.ResultMarshaller.mapAndMarshal"),
+  ProblemFilters.exclude[IncompatibleMethTypeProblem](
+    "sangria.marshalling.ScalaResultMarshaller.mapAndMarshal")
+)
 
 description := "Sangria Marshalling API"
 homepage := Some(url("https://sangria-graphql.github.io/"))

--- a/src/main/scala/sangria/marshalling/ResultMarshaller.scala
+++ b/src/main/scala/sangria/marshalling/ResultMarshaller.scala
@@ -46,7 +46,7 @@ trait ResultMarshaller {
   def renderCompact(node: Node): String
   def renderPretty(node: Node): String
 
-  def mapAndMarshal[T](seq: Seq[T], fn: T => Node): Node = {
+  def mapAndMarshal[T](seq: Iterable[T], fn: T => Node): Node = {
     val res = new VectorBuilder[Node]
 
     for (elem <- seq)


### PR DESCRIPTION
As a precondition for the enhancement suggested [here](https://github.com/sangria-graphql/sangria/issues/979), this adds slight improvements to the `FromInput` trait, namely:

- introduction of an `Iterable` subtype bound
- introduction of a new implicit, i.e.: `iterableInput`
- loosen type in `mapAndMarshal` signature