### PR TITLE
refactor: address compile time warning

### DIFF
--- a/src/main/scala/sangria/marshalling/InputUnmarshaller.scala
+++ b/src/main/scala/sangria/marshalling/InputUnmarshaller.scala
@@ -12,7 +12,7 @@ trait InputUnmarshaller[Node] {
 
   def isMapNode(node: Node): Boolean
   def getMapValue(node: Node, key: String): Option[Node]
-  def getMapKeys(node: Node): Traversable[String]
+  def getMapKeys(node: Node): Iterable[String]
 
   def isListNode(node: Node): Boolean
   def getListValue(node: Node): Seq[Node]


### PR DESCRIPTION
Next compile time warning addressed:

```
[info] compiling 15 Scala sources to /Users/pavel/devcore/sangria-graphql/sangria-marshalling-api/target/scala-3.3.6/classes ...
[warn] -- Deprecation Warning: /Users/pavel/devcore/sangria-graphql/sangria-marshalling-api/src/main/scala/sangria/marshalling/InputUnmarshaller.scala:15:30
[warn] 15 |  def getMapKeys(node: Node): Traversable[String]
[warn]    |                              ^^^^^^^^^^^
[warn]    |type Traversable in package scala is deprecated since 2.13.0: Use Iterable instead of Traversable
[warn] one warning found
[success] Total time: 2 s, completed 25 Aug 2025, 18:48:34
```